### PR TITLE
Bugfix/fix ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,9 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies

--- a/mdx_attr_cols.py
+++ b/mdx_attr_cols.py
@@ -1,7 +1,8 @@
 """ Bootstrap 3 grid extension fo Python Markdown
 """
 
-from markdown.util import etree
+import xml.etree.ElementTree as etree
+
 from markdown import Extension
 from markdown.treeprocessors import Treeprocessor
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-pytest==6.0.2
-pytest-flake8==1.0.6
-xmltodict==0.12.0
+pytest==9.0.3
+pytest-flake8==1.3.0
+xmltodict==1.0.4

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 REQUIRES = [
     "markdown",
-    "mdx_outline",
+    "mdx_outline @ git+https://github.com/aleray/mdx_outline.git",
 ]
 
 SOURCES = []

--- a/tests.py
+++ b/tests.py
@@ -90,7 +90,7 @@ class TestAttrColExtension(TestCase):
     def test_missing_attr_list(self):
         md = self.mk_markdown(['mdx_outline'])
         ext = AttrColExtension({})
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError,
             "The attr_cols markdown extension depends the following"
             " extensions which must preceded it in the extension list:"
@@ -101,7 +101,7 @@ class TestAttrColExtension(TestCase):
     def test_missing_outline(self):
         md = self.mk_markdown([])
         ext = AttrColExtension({})
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError,
             "The attr_cols markdown extension depends the following"
             " extensions which must preceded it in the extension list:"

--- a/tests.py
+++ b/tests.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
+import xml.etree.ElementTree as etree
 
 import xmltodict
 
 from markdown import Markdown
-from markdown.util import etree
 
 from mdx_attr_cols import AttrColTreeProcessor, AttrColExtension, makeExtension
 


### PR DESCRIPTION
This updates the CI tests to run again and updates the actions to current versions.

This also addresses #7 , since we need to update the pytest version anyway

There's a debate to had about the best way of dealing with mdx_outline - this may not be the best long term approach